### PR TITLE
Potential fix for code scanning alert no. 235: Use of a weak cryptographic key

### DIFF
--- a/benchmark/crypto/keygen.js
+++ b/benchmark/crypto/keygen.js
@@ -43,8 +43,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i) {
       generateKeyPairSync('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       });
     }
     bench.end(n);
@@ -60,8 +60,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i)
       generateKeyPair('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       }, done);
   },
 };


### PR DESCRIPTION
Potential fix for [https://github.com/pwnautopilots/node/security/code-scanning/235](https://github.com/pwnautopilots/node/security/code-scanning/235)

To fix the problem, we need to increase the key length for DSA to at least 2048 bits. This involves updating the `modulusLength` parameter in the `generateKeyPairSync` and `generateKeyPair` functions for both synchronous and asynchronous DSA key generation methods. This change will ensure that the generated keys are secure and comply with modern encryption standards.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
